### PR TITLE
Fix undo passant

### DIFF
--- a/Chess_code/Board.cpp
+++ b/Chess_code/Board.cpp
@@ -136,7 +136,7 @@ If pawn moves 2, I save a Piece pointer to the pawn and the spot that it would h
 been in if it moved 1 in a special PassantPawn object. I call that object SS in this example.
 If the opponent lands on SS THE EXACT TURN AFTER the pawn moved, the pawn dies.
 That means killing the pawn and setting SS's pointer to NULL after making a move on the opponent's turn.
-If an en passant is made, the passant status of the killed pawn is saved in the prevepassant variable,
+If an en passant move is made, the passant status of the killed pawn is saved in the prevepassant variable,
 so that it can be revived if the move is undone.
 
 Note that this function DOESN'T UPGRADE Pawns. The function to upgrade pawns is called upgrade_pawn_if_needed,

--- a/Chess_code/Board.cpp
+++ b/Chess_code/Board.cpp
@@ -306,7 +306,6 @@ int Board::current_turn() const
     return turn_number;
 }
 
-// TODO: Undoing a passant does not bring the killed passant pawn back.
 // IF UNDO You might have to downgrade a pawn.
 // Check if the piece that moved was a pawn and if it moved to the end of the board.
 // If i did then delete team_owner->upgraded_pieces[move_i_made->piece_that_moved->count-8]

--- a/Chess_code/Board.cpp
+++ b/Chess_code/Board.cpp
@@ -136,7 +136,8 @@ If pawn moves 2, I save a Piece pointer to the pawn and the spot that it would h
 been in if it moved 1 in a special PassantPawn object. I call that object SS in this example.
 If the opponent lands on SS THE EXACT TURN AFTER the pawn moved, the pawn dies.
 That means killing the pawn and setting SS's pointer to NULL after making a move on the opponent's turn.
-If an en passant is made, the pre
+If an en passant is made, the passant status of the killed pawn is saved in the prevepassant variable,
+so that it can be revived if the move is undone.
 
 Note that this function DOESN'T UPGRADE Pawns. The function to upgrade pawns is called upgrade_pawn_if_needed,
 and it's called after this function is called in Chess.cpp.

--- a/Chess_code/Board.cpp
+++ b/Chess_code/Board.cpp
@@ -133,13 +133,13 @@ That's because a person starts counting spaces with 1 but the computer starts co
 Detects if the move lands on an enemy piece and stores the enemy piece in the move in case it is un-done.
 
 If pawn moves 2, I save a Piece pointer to the pawn and the spot that it would have
-been in if it moved 1. I call that space SS in this example.
+been in if it moved 1 in a special PassantPawn object. I call that object SS in this example.
 If the opponent lands on SS THE EXACT TURN AFTER the pawn moved, the pawn dies.
-That means setting the pawn and SS both to NULL after making a move on the opponent's turn.
-Check if you did the passant before clearing it and hopefully everything will work.
+That means killing the pawn and setting SS's pointer to NULL after making a move on the opponent's turn.
+If an en passant is made, the pre
 
-Note that this function  but DOESN'T UPGRADE Pawns.
-TODO: SAVE WHEN A PASSANT PAWN IS CAPTURED SO IT CAN BE REVIVED WHEN THE MOVE IS UNDONE.
+Note that this function DOESN'T UPGRADE Pawns. The function to upgrade pawns is called upgrade_pawn_if_needed,
+and it's called after this function is called in Chess.cpp.
 */
 bool Board::human_move_piece(Move* move_to_make) {
     if (move_to_make == NULL) {

--- a/Chess_code/Board.cpp
+++ b/Chess_code/Board.cpp
@@ -289,13 +289,14 @@ bool Board::human_move_piece(Move* move_to_make) {
 }
 
 void Board::kill_passant() {
-    //TODO: Save the deleted passant pawn in case an undo is made.
     if (passantpawn.get_piece() == NULL) {
         throw InvalidMove("No passant pawn to kill.");
     }
     passantpawn.get_piece()->alive = false;
     spaces[passantpawn.get_piece()->row - 1][passantpawn.get_piece()->column - 1] = NULL;
     //This is safe because doing a passant will NEVER be followed by a passant.
+    //Save the deleted passant pawn in case an undo is made.
+    prevepassant = passantpawn;
     passantpawn = PassantPawn();
 }
 
@@ -312,7 +313,14 @@ int Board::current_turn() const
 // Note: IT IS VERY IMPORTANT IN THE LIVE GAME TO ALWAYS PASS THE TEAM THAT MOVED!
 //BUG: Undoing an en passant does not reset the passant pawn.
 void Board::undo_move(Move* move_i_made, Team* team_that_moved) {
+    
     passantpawn = prevepassant;
+    //Revive the passant pawn if he was killed.
+    Pawn* last_passant = passantpawn.get_piece();
+    if (last_passant != NULL) {
+        last_passant->alive = true;
+        spaces[last_passant->row - 1][last_passant->column - 1] = last_passant;
+    }
     prevepassant = PassantPawn();
     int previousrow = move_i_made->end_row;
     int previouscolumn = move_i_made->end_column;

--- a/Chess_code/Board.cpp
+++ b/Chess_code/Board.cpp
@@ -343,8 +343,6 @@ void Board::undo_move(Move* move_i_made, Team* team_that_moved) {
             break;
         }
 
-        //TODO: Use information from the move and the memory you should have about the en passant pawn to undo the passant.
-
         //Undo the upgrade.
         if (team_that_moved != NULL && did_upgrade) {
             // Assume we're the white team.

--- a/Chess_code/Board.cpp
+++ b/Chess_code/Board.cpp
@@ -139,6 +139,7 @@ That means setting the pawn and SS both to NULL after making a move on the oppon
 Check if you did the passant before clearing it and hopefully everything will work.
 
 Note that this function  but DOESN'T UPGRADE Pawns.
+TODO: SAVE WHEN A PASSANT PAWN IS CAPTURED SO IT CAN BE REVIVED WHEN THE MOVE IS UNDONE.
 */
 bool Board::human_move_piece(Move* move_to_make) {
     if (move_to_make == NULL) {
@@ -303,7 +304,8 @@ int Board::current_turn() const
     return turn_number;
 }
 
-//IF UNDO You might have to downgrade a pawn.
+// TODO: Undoing a passant does not bring the killed passant pawn back.
+// IF UNDO You might have to downgrade a pawn.
 // Check if the piece that moved was a pawn and if it moved to the end of the board.
 // If i did then delete team_owner->upgraded_pieces[move_i_made->piece_that_moved->count-8]
 // THEN SET IT TO NULL RIGHT AFTER!
@@ -319,6 +321,7 @@ void Board::undo_move(Move* move_i_made, Team* team_that_moved) {
         throw InvalidPiece(NULL);
     }
 
+    //Undo upgrades here.
     if (move_i_made->piece_that_moved->piecetype == TYPE::PAWN) {
         Pawn* movedpawn = (Pawn*)move_i_made->piece_that_moved;
         bool did_upgrade = false;
@@ -332,6 +335,9 @@ void Board::undo_move(Move* move_i_made, Team* team_that_moved) {
             break;
         }
 
+        //TODO: Use information from the move and the memory you should have about the en passant pawn to undo the passant.
+
+        //Undo the upgrade.
         if (team_that_moved != NULL && did_upgrade) {
             // Assume we're the white team.
             int piecenum = movedpawn->get_start_column() + 7;

--- a/Chess_code/Team.cpp
+++ b/Chess_code/Team.cpp
@@ -49,7 +49,17 @@ Team::~Team() {
     }
 }
 
-Team::Team(COLOR team_color, Board *the_board_shared) :the_king(COLOR::WHITE)
+Team::Team(COLOR team_color, Board *the_board_shared) :the_king(COLOR::WHITE) /* Sets up the team on the board.
+ * The team_color is the color of the team, either WHITE or BLACK.
+ * the_board_shared is a pointer to the board on which the game will be played.
+ * The black team looks at the board facing the opposite direction that the white team does,
+ * so at the start of the game,
+ * the white team's pawn n is the black team's pawn 9-n, where n is the visible pawn number, NOT the index.
+ * NOTE: With i as the visible column number,
+ *       the index in the white team's pawn array of the pawn that starts in column i is i-1,
+ *       and the index in the black team's pawn array of the pawn that starts in column i is 8-i.
+ */
+
 {
     //NOTE THE QUEEN AND KING SHOULD SWAP
     enemy_team = nullptr;
@@ -91,7 +101,7 @@ Team::Team(COLOR team_color, Board *the_board_shared) :the_king(COLOR::WHITE)
         queen = Queen(team_color, 8, 4, 0);
         for (int i = 1; i <= 8; i++) {
             /*The black king looks at his pawns from the opposite angle, so he calls the
-            * pawn in the absolute top left pawn corner pawn 8. That means pawns[8-1], (or in other words pawns[7]) is in row 7 column 1.
+            * pawn in the absolute top left pawn corner is pawn 8. That means pawns[8-1], (or in other words pawns[7]) is in row 7 column 1.
             * I know it's kinda confusing that the pawns are created from the team's perspective while the other pieces are created from the top-down perspective,
             * but to make it easier, just think of the pawn's index as the 8 - the pawn's column.
               */

--- a/Test_Chess.cpp
+++ b/Test_Chess.cpp
@@ -545,6 +545,31 @@ TEST_CASE("The passant pawn status is saved and loaded correctly with a black pa
     printf("Works for black pawns!\n");
 }
 
+TEST_CASE("Undoing a successful en passant keeps the victim alive", "[undo][passant]") {
+    Board mainboard;
+    Team whiteteam = Team(COLOR::WHITE, &mainboard);
+    Team blackteam = Team(COLOR::BLACK, &mainboard);
+    Move firstmove = mainboard.make_move(&whiteteam.pawns[5 - 1], 4, 5);
+    Move secondmove = mainboard.make_move(&whiteteam.pawns[5 - 1], 5, 5);
+    Move thirdmove = mainboard.make_move(&blackteam.pawns[8 - 6], 5, 6);
+    mainboard.human_move_piece(&firstmove);
+    mainboard.print_board();
+    mainboard.human_move_piece(&secondmove);
+    mainboard.print_board();
+    mainboard.human_move_piece(&thirdmove);
+    mainboard.print_board();
+    REQUIRE(mainboard.passantpawn.get_piece() == &blackteam.pawns[8 - 6]);
+    Move passantmove = mainboard.make_move(&whiteteam.pawns[5 - 1], 6, 6);
+    mainboard.human_move_piece(&passantmove);
+    REQUIRE_FALSE(blackteam.pawns[8-6].alive);
+    mainboard.print_board();
+    mainboard.undo_move(&passantmove, &whiteteam);
+    mainboard.print_board();
+    REQUIRE(blackteam.pawns[6 - 1].alive);
+    REQUIRE(mainboard.passantpawn.get_piece() == &blackteam.pawns[8 - 6]);
+    REQUIRE(mainboard.spaces[5 - 1][6 - 1] == &blackteam.pawns[8 - 6]);
+}
+
 TEST_CASE("Throws errors upgrading pawns to themselves", "[errors]") {
     Board mainboard;
     Team whiteteam = Team(COLOR::WHITE, &mainboard);


### PR DESCRIPTION
Previously, I found a bug where if you were in check while you were able to do an en passant move, if you did it and then undid it, the pawn that you captured with the en passant move would still be captured, even though it should be alive since you changed your mind about killing it.

I fixed that bug.